### PR TITLE
Remove connection switching

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,23 +4,7 @@ class SearchController < ApplicationController
   # You can implement pattern searching using LIKE clause
   # Example : SELECT * FROM patients WHERE first_name LIKE "%pattern%";
 
-  def with_read_only_connection
-    original_connection = ActiveRecord::Base.remove_connection
-    ActiveRecord::Base.establish_connection(:development)
-    ActiveRecord::Base.connection.execute("set session characteristics as transaction read only;")
-    yield
-  ensure
-    ActiveRecord::Base.establish_connection(original_connection)
-  end
-
   def index
-    # query = params[:query]
-    # res = with_read_only_connection do
-    #   ActiveRecord::Base.connection.execute("#{query}")
-    # end
-    # render json: res.to_json
-
-    # sending asha members info to AutoComplete react component
     result = User.where(role: "asha").select(:id, :full_name)
     data = result.map { |r| r.attributes.symbolize_keys }
     render :json => data


### PR DESCRIPTION
The ActiveRecord::Base.connection is common across all requests for a single process. _(There is typically a pool of connections for performance, but that's typically a hidden detail -- https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html)_. 

So if we remove/switch the connection inside a request, it is going to affect other concurrent requests being served by our Rails application. It is also not idiomatic in Rails to be modifying the database connection properties anywhere except the database.yml config, or in some cases, in the application initializers.

We also don't need to worry about read-only vs write ability inside a regular web application. Instead we simply have to be careful in the code we write and back it up with tests so that the app doesn't do anything destructive with the data.

--

I've also removed the commented out code -- we should clean up the code before we commit to origin. It is okay to leave them while development, but the code that is in `main` should always be clean and well-tested.