### PR TITLE
Fix new users created by admin error

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,7 +33,8 @@ class UsersController < ApplicationController
   def create
     user = params.require(:user).permit(:full_name, :first_name, :role, :email, :phone, :password, :verified)
     user[:verified] = false
-    if user[:password].strip.empty?
+
+    if !user[:password] || user[:password].strip.empty?
       user[:password] = "arike"
     end
 


### PR DESCRIPTION
When the admin adds the new user, the password field doesn't even exist, so `user[:password].strip` was giving an error saying strip is not available in `nil` class. So, I added a check if the `user[:password]` even exists. 