### PR TITLE
🔨 Fix: Build .res Dependencies on Test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN bundle install
 ADD . $APP_HOME
 
 RUN yarn install
+RUN yarn run re:build
 
 ENV RAILS_SERVE_STATIC_FILES=true
 ENV RAILS_ENV=production


### PR DESCRIPTION
During the Docker Build,

- `RUN yarn install` after installing all the dependencies,  added the `RUN yarn run re:build` command to build the dependency files once, so that `NoModuleError` on the JS side can fixed.
- Also, during the build, it will also compile our other .res file too.

File Changed: `Dockerfile`