### PR TITLE
fixed info icon click propagation issue in Schedule

### DIFF
--- a/app/javascript/schedule/components/UnselectedPatient.res
+++ b/app/javascript/schedule/components/UnselectedPatient.res
@@ -10,12 +10,12 @@ let make = (~patient: patient, ~selectPatient) => {
     className="col-span-1 bg-white rounded-lg shadow divide-y divide-gray-200 hover:bg-gray-100 flex items-center">
     <div className="w-full flex justify-between p-6 space-x-6">
       <div className="flex-1 truncate">
-        <div className=" items-center space-x-3 justify-self-start">
+        <div className="items-center space-x-3 justify-self-start">
           <h3
             className="text-gray-900 text-md font-bold cursor-pointer"
-            onClick={_ => {
+            onClick={event => {
+              event->ReactEvent.Mouse.stopPropagation
               window["location"]["href"] = `patients/${patient.id}`
-              Js.Global.setTimeout(() => (), 100000000)->ignore
             }}>
             {s(patient.name)} <i className="fas fa-info-circle ml-2" />
           </h3>


### PR DESCRIPTION
Fixes #114 

Now when the info icon in the patient card is clicked, it only redirects the user to patient info page
